### PR TITLE
Log parent threads spawned before fork

### DIFF
--- a/firehot/__tests__/embedded/test_parent_entrypoint.py
+++ b/firehot/__tests__/embedded/test_parent_entrypoint.py
@@ -1,8 +1,9 @@
 import logging
 import sys
+import threading
 from time import sleep
 
-from firehot.embedded.parent_entrypoint import MultiplexedStream
+from firehot.embedded.parent_entrypoint import MultiplexedStream, check_thread_safety
 
 
 def test_print_redirection(capfd):
@@ -106,3 +107,58 @@ def test_multiline_print_prefix(capfd):
         # Extract the actual content after the prefix.
         content = line.split("]")[-1]
         assert content.strip() == expected
+
+
+def test_thread_safety_check(caplog):
+    """
+    Test that check_thread_safety correctly identifies and logs information about multiple threads.
+    We create a background thread that sleeps, then verify the warning messages contain the
+    expected thread information.
+    """
+    # Set up logging to capture warnings
+    caplog.set_level(logging.WARNING)
+
+    def background_task():
+        # Simple task that just sleeps, giving us time to inspect it
+        sleep(0.5)
+
+    # Create and start a background thread
+    background_thread = threading.Thread(
+        target=background_task, name="TestBackgroundThread", daemon=True
+    )
+    background_thread.start()
+
+    try:
+        # Run the thread safety check
+        check_thread_safety()
+
+        # Verify the warning messages
+        warnings = [record for record in caplog.records if record.levelname == "WARNING"]
+
+        # Should have at least 2 warnings: initial warning and thread details
+        assert len(warnings) >= 2, "Expected at least 2 warning messages"
+
+        # Check the content of the first warning
+        initial_warning = warnings[0].message
+        assert "Detected 2 active threads before fork()" in initial_warning
+        assert "deadlocks and memory corruption" in initial_warning
+
+        # Check the thread details warnings
+        thread_details = "".join(record.message for record in warnings[1:])
+
+        # Verify both threads are logged
+        assert "Name: MainThread" in thread_details
+        assert "Name: TestBackgroundThread" in thread_details
+
+        # Verify key thread information is present
+        assert "ID:" in thread_details
+        assert "Daemon:" in thread_details
+        assert "Alive:" in thread_details
+        assert "Stack Trace:" in thread_details
+
+        # Verify our background task function appears in the stack trace
+        assert "background_task" in thread_details
+
+    finally:
+        # Clean up by waiting for background thread to complete
+        background_thread.join(timeout=1.0)


### PR DESCRIPTION
Forking after multithreading is unreliable, since thread states are not copied alongside the multi-threading and can lead to stray mutexes that aren't ever closed.