### PR TITLE
Log c-level threads

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -63,6 +63,12 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install library
+        run: uv run maturin develop --uv
+
       - name: Run Cargo tests
         env:
           FIREHOT_LOG_LEVEL: trace

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
+      # Even cargo tests need python/the lib built and installed, so our
+      # embedded scripts can reference rust functions.
       - name: Install library
         run: uv run maturin develop --uv
 

--- a/firehot/embedded/parent_entrypoint.py
+++ b/firehot/embedded/parent_entrypoint.py
@@ -20,7 +20,9 @@ from json import loads as json_loads
 from json.decoder import JSONDecodeError
 from os import getenv
 from time import sleep
-from traceback import format_exc
+from traceback import format_exc, format_stack
+from sys import _current_frames
+from firehot import get_total_thread_count
 
 try:
     from enum import StrEnum
@@ -344,48 +346,56 @@ def check_thread_safety() -> None:
     https://blog.phusion.nl/2017/10/13/why-ruby-app-servers-break-on-macos-high-sierra-and-what-can-be-done-about-it/
 
     """
-    import threading
-    import traceback
-    from sys import _current_frames
+    # Get the total thread count from our Rust implementation
+    # This will catch ALL threads, including those spawned by C extensions
+    total_thread_count = get_total_thread_count()
+    
+    if total_thread_count == 1:
+        return
 
-    active_threads = threading.enumerate()
-    thread_count = len(active_threads)
+    firehot_logger = build_firehot_logger()
+    firehot_logger.warning(
+        f"WARNING: Detected {total_thread_count} active threads before fork() "
+        f"({threading.active_count()} Python threads, {total_thread_count - threading.active_count()} C/native threads). "
+        "Forking a process with multiple threads can lead to deadlocks and "
+        "memory corruption, especially on macOS. Any threads besides the main "
+        "thread will be terminated in the child process, potentially leaving "
+        "shared resources in an inconsistent state."
+    )
 
-    if thread_count > 1:
-        firehot_logger = build_firehot_logger()
+    # Get stack traces for all Python threads
+    thread_frames = _current_frames()
+    
+    # Log details about each Python thread
+    for thread in threading.enumerate():
+        thread_id = thread.ident
+        if thread_id in thread_frames:
+            stack = "".join(format_stack(thread_frames[thread_id]))
+            firehot_logger.warning(
+                f"\nPython Thread Details:\n"
+                f"  Name: {thread.name}\n"
+                f"  ID: {thread_id}\n"
+                f"  Daemon: {thread.daemon}\n"
+                f"  Alive: {thread.is_alive()}\n"
+                f"  Stack Trace:\n{stack}"
+            )
+        else:
+            firehot_logger.warning(
+                f"\nPython Thread Details:\n"
+                f"  Name: {thread.name}\n"
+                f"  ID: {thread_id}\n"
+                f"  Daemon: {thread.daemon}\n"
+                f"  Alive: {thread.is_alive()}\n"
+                f"  Stack Trace: Unable to retrieve"
+            )
+
+    if total_thread_count > threading.active_count():
         firehot_logger.warning(
-            f"WARNING: Detected {thread_count} active threads before fork(). "
-            "Forking a process with multiple threads can lead to deadlocks and "
-            "memory corruption, especially on macOS. Any threads besides the main "
-            "thread will be terminated in the child process, potentially leaving "
-            "shared resources in an inconsistent state."
+            f"\nWARNING: Detected {total_thread_count - threading.active_count()} "
+            "threads that were created outside of Python (likely from C extensions). "
+            "These threads cannot be inspected from Python but may still cause "
+            "issues during fork()."
         )
-
-        # Get stack traces for all threads
-        thread_frames = _current_frames()
-
-        # Log details about each thread
-        for thread in active_threads:
-            thread_id = thread.ident
-            if thread_id in thread_frames:
-                stack = "".join(traceback.format_stack(thread_frames[thread_id]))
-                firehot_logger.warning(
-                    f"\nThread Details:\n"
-                    f"  Name: {thread.name}\n"
-                    f"  ID: {thread_id}\n"
-                    f"  Daemon: {thread.daemon}\n"
-                    f"  Alive: {thread.is_alive()}\n"
-                    f"  Stack Trace:\n{stack}"
-                )
-            else:
-                firehot_logger.warning(
-                    f"\nThread Details:\n"
-                    f"  Name: {thread.name}\n"
-                    f"  ID: {thread_id}\n"
-                    f"  Daemon: {thread.daemon}\n"
-                    f"  Alive: {thread.is_alive()}\n"
-                    f"  Stack Trace: Unable to retrieve"
-                )
 
 
 #

--- a/firehot/embedded/parent_entrypoint.py
+++ b/firehot/embedded/parent_entrypoint.py
@@ -19,10 +19,11 @@ from json import dumps as json_dumps
 from json import loads as json_loads
 from json.decoder import JSONDecodeError
 from os import getenv
+from sys import _current_frames
 from time import sleep
 from traceback import format_exc, format_stack
-from sys import _current_frames
-from firehot import get_total_thread_count
+
+from firehot.firehot import get_total_thread_count
 
 try:
     from enum import StrEnum
@@ -346,14 +347,15 @@ def check_thread_safety() -> None:
     https://blog.phusion.nl/2017/10/13/why-ruby-app-servers-break-on-macos-high-sierra-and-what-can-be-done-about-it/
 
     """
+    firehot_logger = build_firehot_logger()
+
     # Get the total thread count from our Rust implementation
     # This will catch ALL threads, including those spawned by C extensions
     total_thread_count = get_total_thread_count()
-    
+
     if total_thread_count == 1:
         return
 
-    firehot_logger = build_firehot_logger()
     firehot_logger.warning(
         f"WARNING: Detected {total_thread_count} active threads before fork() "
         f"({threading.active_count()} Python threads, {total_thread_count - threading.active_count()} C/native threads). "
@@ -365,7 +367,7 @@ def check_thread_safety() -> None:
 
     # Get stack traces for all Python threads
     thread_frames = _current_frames()
-    
+
     # Log details about each Python thread
     for thread in threading.enumerate():
         thread_id = thread.ident

--- a/firehot/embedded/parent_entrypoint.py
+++ b/firehot/embedded/parent_entrypoint.py
@@ -222,12 +222,6 @@ class MultiplexedStream:
         self.monitor_thread = threading.Thread(target=self._monitor_pipe, daemon=True)
         self.monitor_thread.start()
 
-        # Update Python's sys.stdout/stderr to use new fd
-        # if self.stream_name == "stdout":
-        #    sys.stdout = os.fdopen(self.original_fd, "w", 1)  # line buffered
-        # else:
-        #    sys.stderr = os.fdopen(self.original_fd, "w", 1)  # line buffered
-
         # This ensures that the file object used for sys.stdout (or sys.stderr) does
         # not own (and eventually close) the original descriptor. We want to be in
         # charge of that closure process.
@@ -379,7 +373,7 @@ def check_thread_safety() -> None:
                 f"  ID: {thread_id}\n"
                 f"  Daemon: {thread.daemon}\n"
                 f"  Alive: {thread.is_alive()}\n"
-                f"  Stack Trace:\n{stack}"
+                f"  Stack Trace:\n{stack.rstrip()}"
             )
         else:
             firehot_logger.warning(
@@ -430,6 +424,8 @@ def main():
             # Child process
 
             # Set up stream redirection to catch all output from the child process
+            # NOTE: We can't run this before the child process has launched, since it spawns
+            # a thread that will affect our fork() behavior.
             with MultiplexedStream.setup_stream_redirection():
                 try:
                     # Set up globals and locals for execution

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -389,7 +389,8 @@ impl Layer {
                     forked_processes,
                     forked_names,
                 ) {
-                    error!("Error handling log format: {}", line);
+                    // Unable to parse the line as a message, so log it as a raw line
+                    error!("{}", line);
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod environment;
 pub mod layer;
 pub mod messages;
 pub mod multiplex_logs;
+pub mod process;
 pub mod scripts;
 pub mod test_utils;
 
@@ -76,6 +77,8 @@ fn firehot(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(exec_isolated, m)?)?;
     m.add_function(wrap_pyfunction!(communicate_isolated, m)?)?;
     m.add_function(wrap_pyfunction!(stop_isolated, m)?)?;
+
+    m.add_function(wrap_pyfunction!(get_total_thread_count, m)?)?;
 
     info!("firehot module initialization complete");
     Ok(())
@@ -277,4 +280,10 @@ fn communicate_isolated(_py: Python, env_id: &str, process_uuid: &str) -> PyResu
         error!("{}", err_msg);
         Err(PyRuntimeError::new_err(err_msg))
     }
+}
+
+#[pyfunction]
+fn get_total_thread_count() -> PyResult<u32> {
+    process::get_total_thread_count()
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,130 @@
+use std::io;
+
+#[cfg(target_os = "macos")]
+use libc::{c_int, proc_pidinfo, PROC_PIDTASKINFO};
+
+#[cfg(target_os = "linux")]
+use std::fs;
+
+/// Get the total number of threads for the current process, including threads spawned
+/// by C-level extensions. This is more comprehensive than Python's threading.active_count()
+/// as it uses OS-level APIs to get the true thread count.
+/// 
+/// # Returns
+/// * `Result<u32, io::Error>` - The number of threads or an error if the thread count
+///   could not be determined
+pub fn get_total_thread_count() -> Result<u32, io::Error> {
+    #[cfg(target_os = "macos")]
+    {
+        unsafe {
+            // Define the task info structure
+            #[repr(C)]
+            struct ProcTaskInfo {
+                pti_virtual_size: u64,    // virtual memory size (bytes)
+                pti_resident_size: u64,   // resident memory size (bytes)
+                pti_total_user: u64,      // total time (user)
+                pti_total_system: u64,    // total time (system)
+                pti_threads_user: u64,    // total time (user) for threads
+                pti_threads_system: u64,  // total time (system) for threads
+                pti_policy: c_int,        // default policy
+                pti_faults: i32,         // number of page faults
+                pti_pageins: i32,        // number of actual pageins
+                pti_cow_faults: i32,     // number of copy-on-write faults
+                pti_messages_sent: i32,  // number of messages sent
+                pti_messages_received: i32, // number of messages received
+                pti_syscalls_mach: i32,  // number of mach system calls
+                pti_syscalls_unix: i32,  // number of unix system calls
+                pti_csw: i32,           // number of context switches
+                pti_threadnum: i32,     // number of threads
+                pti_numrunning: i32,    // number of running threads
+                pti_priority: i32,      // task priority
+            }
+
+            let mut task_info: ProcTaskInfo = std::mem::zeroed();
+            let pid = libc::getpid();
+            
+            let result = proc_pidinfo(
+                pid,
+                PROC_PIDTASKINFO,
+                0,
+                &mut task_info as *mut _ as *mut libc::c_void,
+                std::mem::size_of::<ProcTaskInfo>() as i32,
+            );
+
+            if result <= 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(task_info.pti_threadnum as u32)
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // On Linux, we can read the number of threads from /proc/self/status
+        let status = fs::read_to_string("/proc/self/status")?;
+        
+        // Find the Threads line
+        for line in status.lines() {
+            if line.starts_with("Threads:") {
+                // Parse the number after "Threads:"
+                if let Some(count_str) = line.split_whitespace().nth(1) {
+                    if let Ok(count) = count_str.parse::<u32>() {
+                        return Ok(count);
+                    }
+                }
+                break;
+            }
+        }
+        
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "Could not find thread count in /proc/self/status",
+        ))
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "Thread counting is only supported on Linux and macOS",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    #[test]
+    fn test_thread_count() {
+        // Get initial thread count (should be at least 1)
+        let initial_count = get_total_thread_count().unwrap();
+        assert!(initial_count >= 1);
+
+        // Spawn some threads
+        let handles: Vec<_> = (0..3)
+            .map(|_| {
+                thread::spawn(|| {
+                    // Sleep to ensure we can count it
+                    thread::sleep(std::time::Duration::from_millis(100));
+                })
+            })
+            .collect();
+
+        // Sleep briefly to ensure threads are running
+        thread::sleep(std::time::Duration::from_millis(50));
+
+        // Get new thread count
+        let new_count = get_total_thread_count().unwrap();
+        
+        // Should have at least 3 more threads than initial
+        assert!(new_count >= initial_count + 3);
+
+        // Clean up threads
+        for handle in handles {
+            handle.join().unwrap();
+        }
+    }
+} 

--- a/src/process.rs
+++ b/src/process.rs
@@ -9,7 +9,7 @@ use std::fs;
 /// Get the total number of threads for the current process, including threads spawned
 /// by C-level extensions. This is more comprehensive than Python's threading.active_count()
 /// as it uses OS-level APIs to get the true thread count.
-/// 
+///
 /// # Returns
 /// * `Result<u32, io::Error>` - The number of threads or an error if the thread count
 ///   could not be determined
@@ -20,29 +20,29 @@ pub fn get_total_thread_count() -> Result<u32, io::Error> {
             // Define the task info structure
             #[repr(C)]
             struct ProcTaskInfo {
-                pti_virtual_size: u64,    // virtual memory size (bytes)
-                pti_resident_size: u64,   // resident memory size (bytes)
-                pti_total_user: u64,      // total time (user)
-                pti_total_system: u64,    // total time (system)
-                pti_threads_user: u64,    // total time (user) for threads
-                pti_threads_system: u64,  // total time (system) for threads
-                pti_policy: c_int,        // default policy
-                pti_faults: i32,         // number of page faults
-                pti_pageins: i32,        // number of actual pageins
-                pti_cow_faults: i32,     // number of copy-on-write faults
-                pti_messages_sent: i32,  // number of messages sent
+                pti_virtual_size: u64,      // virtual memory size (bytes)
+                pti_resident_size: u64,     // resident memory size (bytes)
+                pti_total_user: u64,        // total time (user)
+                pti_total_system: u64,      // total time (system)
+                pti_threads_user: u64,      // total time (user) for threads
+                pti_threads_system: u64,    // total time (system) for threads
+                pti_policy: c_int,          // default policy
+                pti_faults: i32,            // number of page faults
+                pti_pageins: i32,           // number of actual pageins
+                pti_cow_faults: i32,        // number of copy-on-write faults
+                pti_messages_sent: i32,     // number of messages sent
                 pti_messages_received: i32, // number of messages received
-                pti_syscalls_mach: i32,  // number of mach system calls
-                pti_syscalls_unix: i32,  // number of unix system calls
-                pti_csw: i32,           // number of context switches
-                pti_threadnum: i32,     // number of threads
-                pti_numrunning: i32,    // number of running threads
-                pti_priority: i32,      // task priority
+                pti_syscalls_mach: i32,     // number of mach system calls
+                pti_syscalls_unix: i32,     // number of unix system calls
+                pti_csw: i32,               // number of context switches
+                pti_threadnum: i32,         // number of threads
+                pti_numrunning: i32,        // number of running threads
+                pti_priority: i32,          // task priority
             }
 
             let mut task_info: ProcTaskInfo = std::mem::zeroed();
             let pid = libc::getpid();
-            
+
             let result = proc_pidinfo(
                 pid,
                 PROC_PIDTASKINFO,
@@ -63,7 +63,7 @@ pub fn get_total_thread_count() -> Result<u32, io::Error> {
     {
         // On Linux, we can read the number of threads from /proc/self/status
         let status = fs::read_to_string("/proc/self/status")?;
-        
+
         // Find the Threads line
         for line in status.lines() {
             if line.starts_with("Threads:") {
@@ -76,7 +76,7 @@ pub fn get_total_thread_count() -> Result<u32, io::Error> {
                 break;
             }
         }
-        
+
         Err(io::Error::new(
             io::ErrorKind::NotFound,
             "Could not find thread count in /proc/self/status",
@@ -118,7 +118,7 @@ mod tests {
 
         // Get new thread count
         let new_count = get_total_thread_count().unwrap();
-        
+
         // Should have at least 3 more threads than initial
         assert!(new_count >= initial_count + 3);
 
@@ -127,4 +127,4 @@ mod tests {
             handle.join().unwrap();
         }
     }
-} 
+}

--- a/src/process.rs
+++ b/src/process.rs
@@ -108,7 +108,7 @@ mod tests {
             .map(|_| {
                 thread::spawn(|| {
                     // Sleep to ensure we can count it
-                    thread::sleep(std::time::Duration::from_millis(100));
+                    thread::sleep(std::time::Duration::from_millis(500));
                 })
             })
             .collect();


### PR DESCRIPTION
Expand the logic in https://github.com/piercefreeman/firehot/pull/19 to alert for multithreading errors pre-fork caused by C-level extensions. Our existing logic only covers Python threads.

This catches issues when importing `numpy`, which on initialization can spawn ~9 threads to support numerical calculation. Once identified, disabling is simple with env variables: `OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 poetry run runserver`.