### PR TITLE
Selectively ignore packages

### DIFF
--- a/firehot/__tests__/test_context.py
+++ b/firehot/__tests__/test_context.py
@@ -1,7 +1,7 @@
 import importlib
 from pathlib import Path
 
-from firehot.context import resolve_package_metadata
+from firehot.context import isolate_imports, resolve_package_metadata
 
 
 def test_resolve_package_metadata(sample_package):
@@ -29,3 +29,19 @@ def test_resolve_package_metadata(sample_package):
 
     # Check that the directory name matches the package name
     assert resolved_path.name == sample_package
+
+
+def test_isolate_imports(sample_package):
+    """
+    Test that isolate_imports correctly creates an isolated environment and accepts ignored_modules.
+    """
+    # Test basic functionality without ignored modules
+    with isolate_imports(sample_package) as env:
+        assert env.runner_id is not None, "Expected runner_id to be set"
+
+    # Test with ignored modules
+    ignored = ["numpy", "pandas"]
+    with isolate_imports(sample_package, ignored_modules=ignored) as env:
+        assert env.runner_id is not None, "Expected runner_id to be set"
+        # The runner_id should be different from the previous one
+        assert isinstance(env.runner_id, str), "Expected runner_id to be a string"

--- a/firehot/context.py
+++ b/firehot/context.py
@@ -42,18 +42,21 @@ def resolve_package_metadata(package: str) -> tuple[str, str]:
 
 
 @contextmanager
-def isolate_imports(package: str):
+def isolate_imports(package: str, *, ignored_modules: list[str] | None = None):
     """
     Context manager that isolates imports for the given package path.
 
     :param package: Package to isolate imports. This must be importable from the current
                     virtual environment
+    :param ignored_modules: Optional list of module names to ignore during hot reloading.
+                          Changes to these modules will not trigger reloads.
     :yields: An Environment object that can be used to execute code in the isolated environment
+
     """
     package_path, package_name = resolve_package_metadata(package)
     runner_id: str | None = None
     try:
-        runner_id = start_import_runner_rs(package_name, package_path)
+        runner_id = start_import_runner_rs(package_name, package_path, ignored_modules)
         yield Environment(runner_id)
     finally:
         if runner_id:

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -50,7 +50,11 @@ pub struct ProjectAstManager {
 
 impl ProjectAstManager {
     /// Create a new ProjectAstManager for the given project path
-    pub fn new(project_name: &str, project_path: &str, ignored_modules: Option<HashSet<String>>) -> Self {
+    pub fn new(
+        project_name: &str,
+        project_path: &str,
+        ignored_modules: Option<HashSet<String>>,
+    ) -> Self {
         debug!(
             "Creating new ProjectAstManager for {} at {}",
             project_name, project_path
@@ -368,7 +372,8 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let file_path = create_temp_py_file(&temp_dir, "test.py", "print('hello')");
 
-        let manager = ProjectAstManager::new("test_package", temp_dir.path().to_str().unwrap(), None);
+        let manager =
+            ProjectAstManager::new("test_package", temp_dir.path().to_str().unwrap(), None);
         let hash_result = manager.calculate_file_hash(file_path.to_str().unwrap());
 
         assert!(hash_result.is_ok());
@@ -620,7 +625,8 @@ def function():
         let python_code = "import os\nimport sys";
         let file_path = create_temp_py_file(&temp_dir, "test_file.py", python_code);
 
-        let mut manager = ProjectAstManager::new("test_package", temp_dir.path().to_str().unwrap(), None);
+        let mut manager =
+            ProjectAstManager::new("test_package", temp_dir.path().to_str().unwrap(), None);
         let imports_result = manager.process_py_file(file_path.to_str().unwrap());
 
         assert!(imports_result.is_ok());
@@ -638,7 +644,8 @@ def function():
         let file_path = create_temp_py_file(&temp_dir, "test_cache.py", python_code);
         let path_str = file_path.to_str().unwrap();
 
-        let mut manager = ProjectAstManager::new("test_package", temp_dir.path().to_str().unwrap(), None);
+        let mut manager =
+            ProjectAstManager::new("test_package", temp_dir.path().to_str().unwrap(), None);
 
         // First call should parse the file
         let _ = manager.process_py_file(path_str).unwrap();
@@ -677,7 +684,8 @@ def function():
         let file1_path = create_temp_py_file(&temp_dir, "file1.py", "import os\nimport requests");
         let _file2_path = create_temp_py_file(&temp_dir, "file2.py", "import sys\nimport flask");
 
-        let mut manager = ProjectAstManager::new("testpkg", temp_dir.path().to_str().unwrap(), None);
+        let mut manager =
+            ProjectAstManager::new("testpkg", temp_dir.path().to_str().unwrap(), None);
 
         // Initial processing
         let initial_imports = manager.process_all_py_files().unwrap();
@@ -728,7 +736,7 @@ from . import local_module
         let mut ignored_modules = HashSet::new();
         ignored_modules.insert("pandas".to_string());
         ignored_modules.insert("requests".to_string());
-        
+
         let mut manager = ProjectAstManager::new(
             "my_package",
             temp_dir.path().to_str().unwrap(),
@@ -739,34 +747,64 @@ from . import local_module
         let third_party_imports = manager.process_all_py_files().unwrap();
 
         // Verify that ignored modules are not included in third-party imports
-        assert!(!third_party_imports.contains("pandas"), "pandas should be ignored");
-        assert!(!third_party_imports.contains("requests"), "requests should be ignored");
+        assert!(
+            !third_party_imports.contains("pandas"),
+            "pandas should be ignored"
+        );
+        assert!(
+            !third_party_imports.contains("requests"),
+            "requests should be ignored"
+        );
 
         // But other third-party modules should be included
         assert!(third_party_imports.contains("os"), "os should be included");
-        assert!(third_party_imports.contains("sys"), "sys should be included");
+        assert!(
+            third_party_imports.contains("sys"),
+            "sys should be included"
+        );
 
         // First-party imports should still be excluded
-        assert!(!third_party_imports.contains("my_package.utils"), "my_package.utils should not be included");
-        assert!(!third_party_imports.contains("local_module"), "local_module should not be included");
+        assert!(
+            !third_party_imports.contains("my_package.utils"),
+            "my_package.utils should not be included"
+        );
+        assert!(
+            !third_party_imports.contains("local_module"),
+            "local_module should not be included"
+        );
 
         // Now test with no ignored modules
-        let mut manager_no_ignore = ProjectAstManager::new(
-            "my_package",
-            temp_dir.path().to_str().unwrap(),
-            None,
-        );
+        let mut manager_no_ignore =
+            ProjectAstManager::new("my_package", temp_dir.path().to_str().unwrap(), None);
 
         let all_third_party_imports = manager_no_ignore.process_all_py_files().unwrap();
 
         // Without ignore list, all third-party modules should be included
-        assert!(all_third_party_imports.contains("pandas"), "pandas should be included when not ignored");
-        assert!(all_third_party_imports.contains("requests"), "requests should be included when not ignored");
-        assert!(all_third_party_imports.contains("os"), "os should be included");
-        assert!(all_third_party_imports.contains("sys"), "sys should be included");
+        assert!(
+            all_third_party_imports.contains("pandas"),
+            "pandas should be included when not ignored"
+        );
+        assert!(
+            all_third_party_imports.contains("requests"),
+            "requests should be included when not ignored"
+        );
+        assert!(
+            all_third_party_imports.contains("os"),
+            "os should be included"
+        );
+        assert!(
+            all_third_party_imports.contains("sys"),
+            "sys should be included"
+        );
 
         // First-party imports should still be excluded
-        assert!(!all_third_party_imports.contains("my_package.utils"), "my_package.utils should not be included");
-        assert!(!all_third_party_imports.contains("local_module"), "local_module should not be included");
+        assert!(
+            !all_third_party_imports.contains("my_package.utils"),
+            "my_package.utils should not be included"
+        );
+        assert!(
+            !all_third_party_imports.contains("local_module"),
+            "local_module should not be included"
+        );
     }
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -30,7 +30,11 @@ pub struct Environment {
 }
 
 impl Environment {
-    pub fn new(project_name: &str, project_path: &str, ignored_modules: Option<HashSet<String>>) -> Self {
+    pub fn new(
+        project_name: &str,
+        project_path: &str,
+        ignored_modules: Option<HashSet<String>>,
+    ) -> Self {
         // Create a new AST manager for this project
         let ast_manager = ProjectAstManager::new(project_name, project_path, ignored_modules);
         info!("Created AST manager for project: {}", project_name);
@@ -45,7 +49,11 @@ impl Environment {
     }
 
     /// Create a new Environment in test mode (buffers output instead of printing)
-    pub fn new_for_test(project_name: &str, project_path: &str, ignored_modules: Option<HashSet<String>>) -> Self {
+    pub fn new_for_test(
+        project_name: &str,
+        project_path: &str,
+        ignored_modules: Option<HashSet<String>>,
+    ) -> Self {
         // Create a new AST manager for this project
         let ast_manager = ProjectAstManager::new(project_name, project_path, ignored_modules);
         info!("Created AST manager for project: {}", project_name);

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -30,9 +30,9 @@ pub struct Environment {
 }
 
 impl Environment {
-    pub fn new(project_name: &str, project_path: &str) -> Self {
+    pub fn new(project_name: &str, project_path: &str, ignored_modules: Option<HashSet<String>>) -> Self {
         // Create a new AST manager for this project
-        let ast_manager = ProjectAstManager::new(project_name, project_path);
+        let ast_manager = ProjectAstManager::new(project_name, project_path, ignored_modules);
         info!("Created AST manager for project: {}", project_name);
 
         Self {
@@ -45,9 +45,9 @@ impl Environment {
     }
 
     /// Create a new Environment in test mode (buffers output instead of printing)
-    pub fn new_for_test(project_name: &str, project_path: &str) -> Self {
+    pub fn new_for_test(project_name: &str, project_path: &str, ignored_modules: Option<HashSet<String>>) -> Self {
         // Create a new AST manager for this project
-        let ast_manager = ProjectAstManager::new(project_name, project_path);
+        let ast_manager = ProjectAstManager::new(project_name, project_path, ignored_modules);
         info!("Created AST manager for project: {}", project_name);
 
         Self {
@@ -647,7 +647,7 @@ mod tests {
         // Create a simple Python project
         create_temp_py_file(&temp_dir, "main.py", "print('Hello, world!')");
 
-        let mut runner = Environment::new("test_package", dir_path);
+        let mut runner = Environment::new("test_package", dir_path, None);
         assert_eq!(runner.ast_manager.get_project_path(), dir_path);
 
         // Boot the environment before checking it
@@ -668,7 +668,7 @@ mod tests {
         // Create a simple Python project with initial imports
         create_temp_py_file(&temp_dir, "main.py", "import os\nimport sys");
 
-        let mut runner = Environment::new("test_package", dir_path);
+        let mut runner = Environment::new("test_package", dir_path, None);
 
         // Boot the environment before accessing it
         runner.boot_main().expect("Failed to boot main environment");
@@ -750,7 +750,7 @@ def main():
             crate::test_utils::harness::prepare_script_for_isolation(python_script, "main")
                 .expect("Failed to prepare script for isolation");
 
-        let mut runner = Environment::new("test_package", &python_env.container_path);
+        let mut runner = Environment::new("test_package", &python_env.container_path, None);
 
         // Boot the environment before accessing it
         runner.boot_main().expect("Failed to boot main environment");
@@ -800,7 +800,7 @@ def main():
         let temp_dir = TempDir::new().unwrap();
         let dir_path = temp_dir.path().to_str().unwrap();
 
-        let mut runner = Environment::new("test_package", dir_path);
+        let mut runner = Environment::new("test_package", dir_path, None);
 
         // Boot the environment before accessing it
         runner.boot_main().expect("Failed to boot main environment");
@@ -885,7 +885,7 @@ def main():
         let temp_dir = TempDir::new().unwrap();
         let dir_path = temp_dir.path().to_str().unwrap();
 
-        let mut runner = Environment::new("test_package", dir_path);
+        let mut runner = Environment::new("test_package", dir_path, None);
 
         // Boot the environment before stopping it
         runner.boot_main().expect("Failed to boot main environment");
@@ -921,7 +921,7 @@ def main():
             crate::test_utils::harness::prepare_script_for_isolation(python_script, "main")?;
 
         // Create and boot the Environment
-        let mut runner = Environment::new("test_package", dir_path);
+        let mut runner = Environment::new("test_package", dir_path, None);
         runner.boot_main()?;
 
         // Execute the script in isolation - this should not fail at this point
@@ -980,7 +980,7 @@ def main():
                 .expect("Failed to prepare long-running script for isolation");
 
         // Create and boot environment
-        let mut runner = Environment::new("test_package", &python_env.container_path);
+        let mut runner = Environment::new("test_package", &python_env.container_path, None);
         runner.boot_main().expect("Failed to boot main environment");
 
         // Execute the long-running function

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -648,7 +648,7 @@ def main():
             crate::test_utils::harness::prepare_script_for_isolation(python_script, "main")?;
 
         // Create and boot the Environment
-        let mut runner = Environment::new_for_test("test_package", dir_path);
+        let mut runner = Environment::new_for_test("test_package", dir_path, None);
         runner.boot_main()?;
 
         // Execute the script in isolation
@@ -725,7 +725,7 @@ def main():
             crate::test_utils::harness::prepare_script_for_isolation(python_script, "main")?;
 
         // Create and boot the Environment
-        let mut runner = Environment::new_for_test("test_package", dir_path);
+        let mut runner = Environment::new_for_test("test_package", dir_path, None);
         runner.boot_main()?;
 
         // Execute the script in isolation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,9 @@ use std::{collections::HashMap, time::Instant};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use std::collections::HashSet;
 use std::sync::Mutex;
 use uuid::Uuid;
-use std::collections::HashSet;
 
 pub mod ast;
 pub mod async_resolve;
@@ -87,7 +87,12 @@ fn firehot(_py: Python, m: &PyModule) -> PyResult<()> {
 
 /// Initialize and start the import runner, returning a unique identifier
 #[pyfunction]
-fn start_import_runner(_py: Python, project_name: &str, package_path: &str, ignored_modules: Option<Vec<String>>) -> PyResult<String> {
+fn start_import_runner(
+    _py: Python,
+    project_name: &str,
+    package_path: &str,
+    ignored_modules: Option<Vec<String>>,
+) -> PyResult<String> {
     // Generate a unique ID for this runner
     let env_id = Uuid::new_v4().to_string();
 
@@ -100,7 +105,8 @@ fn start_import_runner(_py: Python, project_name: &str, package_path: &str, igno
     );
 
     // Convert ignored_modules from Vec to HashSet if provided
-    let ignored_modules_set = ignored_modules.map(|modules| modules.into_iter().collect::<HashSet<String>>());
+    let ignored_modules_set =
+        ignored_modules.map(|modules| modules.into_iter().collect::<HashSet<String>>());
 
     // Create the runner object
     info!("Creating environment with ID: {}", env_id);

--- a/src/test_utils/harness.rs
+++ b/src/test_utils/harness.rs
@@ -253,7 +253,7 @@ def main():
         let (pickled_data, python_env) = prepare_script_for_isolation(python_script, "main")?;
 
         // Create a mock Environment
-        let mut runner = Environment::new("test_package", &python_env.container_path);
+        let mut runner = Environment::new("test_package", &python_env.container_path, None);
 
         // Boot the environment
         runner.boot_main()?;


### PR DESCRIPTION
In some cases (like https://github.com/piercefreeman/firehot/issues/22) there are third party packages that auto-spawn threads when initialized. These cases are rare but we should support them appropriately.

This PR adds a kwarg to the `isolate_imports` constructor that allows clients to selectively ignore third party packages during initialization. These will instead be imported for the first time in the child process because the module will be brought into scope during the first-party package import.