### PR TITLE
Fix utf8 crash

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -223,7 +223,7 @@ impl ProjectAstManager {
         let mut hasher = Sha256::new();
         hasher.update(&content);
         let hash = hasher.finalize();
-        let hash_str = format!("{:x}", hash);
+        let hash_str = format!("{hash:x}");
         trace!("Calculated hash for {}: {}", file_path, hash_str);
         Ok(hash_str)
     }
@@ -404,13 +404,13 @@ mod tests {
         assert_eq!(imports.len(), 2);
         assert_eq!(imports[0].module, "os");
         assert_eq!(imports[0].names, vec!["os"]);
-        assert_eq!(imports[0].is_relative, false);
-        assert_eq!(imports[0].is_from_import, false);
+        assert!(!imports[0].is_relative);
+        assert!(!imports[0].is_from_import);
 
         assert_eq!(imports[1].module, "sys");
         assert_eq!(imports[1].names, vec!["sys"]);
-        assert_eq!(imports[1].is_relative, false);
-        assert_eq!(imports[1].is_from_import, false);
+        assert!(!imports[1].is_relative);
+        assert!(!imports[1].is_from_import);
     }
 
     #[test]
@@ -432,13 +432,13 @@ mod tests {
         assert_eq!(imports.len(), 2);
         assert_eq!(imports[0].module, "os");
         assert_eq!(imports[0].names, vec!["path"]);
-        assert_eq!(imports[0].is_relative, false);
-        assert_eq!(imports[0].is_from_import, true);
+        assert!(!imports[0].is_relative);
+        assert!(imports[0].is_from_import);
 
         assert_eq!(imports[1].module, "sys");
         assert_eq!(imports[1].names, vec!["argv", "version"]);
-        assert_eq!(imports[1].is_relative, false);
-        assert_eq!(imports[1].is_from_import, true);
+        assert!(!imports[1].is_relative);
+        assert!(imports[1].is_from_import);
     }
 
     #[test]
@@ -460,13 +460,13 @@ mod tests {
         assert_eq!(imports.len(), 2);
         assert_eq!(imports[0].module, "os");
         assert_eq!(imports[0].names, vec!["os"]);
-        assert_eq!(imports[0].is_relative, false);
-        assert_eq!(imports[0].is_from_import, false);
+        assert!(!imports[0].is_relative);
+        assert!(!imports[0].is_from_import);
 
         assert_eq!(imports[1].module, "sys");
         assert_eq!(imports[1].names, vec!["argv"]);
-        assert_eq!(imports[1].is_relative, false);
-        assert_eq!(imports[1].is_from_import, true);
+        assert!(!imports[1].is_relative);
+        assert!(imports[1].is_from_import);
     }
 
     #[test]
@@ -486,7 +486,7 @@ mod tests {
         let imports = collect_imports(stmts);
 
         // Debugging to understand the actual structure
-        println!("Relative imports found: {:#?}", imports);
+        println!("Relative imports found: {imports:#?}");
 
         // For now, just check that we find something, we'll refine this test
         // after seeing the actual output structure
@@ -494,8 +494,8 @@ mod tests {
 
         // All these should be relative from imports
         for import in &imports {
-            assert_eq!(import.is_from_import, true);
-            assert_eq!(import.is_relative, true);
+            assert!(import.is_from_import);
+            assert!(import.is_relative);
         }
     }
 
@@ -574,14 +574,14 @@ def function():
         // First import: "import time"
         assert_eq!(imports[0].module, "time");
         assert_eq!(imports[0].names, vec!["time"]);
-        assert_eq!(imports[0].is_relative, false);
-        assert_eq!(imports[0].is_from_import, false); // This is a simple import
+        assert!(!imports[0].is_relative);
+        assert!(!imports[0].is_from_import); // This is a simple import
 
         // Second import: "from time import time as time_func"
         assert_eq!(imports[1].module, "time");
         assert_eq!(imports[1].names, vec!["time"]); // Should contain the original name, not the alias
-        assert_eq!(imports[1].is_relative, false);
-        assert_eq!(imports[1].is_from_import, true); // This is a from import
+        assert!(!imports[1].is_relative);
+        assert!(imports[1].is_from_import); // This is a from import
     }
 
     #[test]
@@ -689,7 +689,7 @@ def function():
 
         // Initial processing
         let initial_imports = manager.process_all_py_files().unwrap();
-        println!("Initial imports found: {:#?}", initial_imports);
+        println!("Initial imports found: {initial_imports:#?}");
 
         // Verify we have the expected number of third-party imports
         // os, requests, sys, flask should all be considered third-party
@@ -707,8 +707,8 @@ def function():
 
         // Compute delta - should detect the changes
         let (added, removed) = manager.compute_import_delta().unwrap();
-        println!("Added imports: {:#?}", added);
-        println!("Removed imports: {:#?}", removed);
+        println!("Added imports: {added:#?}");
+        println!("Removed imports: {removed:#?}");
 
         assert!(!added.is_empty());
         assert!(added.contains("pandas"));

--- a/src/async_resolve.rs
+++ b/src/async_resolve.rs
@@ -76,7 +76,7 @@ impl<T: Clone> AsyncResolve<T> {
             let value_lock_result = self.value.lock();
 
             if let Err(e) = &value_lock_result {
-                let err_msg = format!("Failed to lock value mutex: {:?}", e);
+                let err_msg = format!("Failed to lock value mutex: {e:?}");
                 warn!("{}", err_msg);
                 return Err(err_msg);
             }
@@ -98,7 +98,7 @@ impl<T: Clone> AsyncResolve<T> {
         let completion_lock_result = mutex.lock();
 
         if let Err(e) = &completion_lock_result {
-            let err_msg = format!("Failed to lock completion mutex: {:?}", e);
+            let err_msg = format!("Failed to lock completion mutex: {e:?}");
             warn!("{}", err_msg);
             return Err(err_msg);
         }
@@ -112,7 +112,7 @@ impl<T: Clone> AsyncResolve<T> {
             let wait_result = condvar.wait(completed);
 
             if let Err(e) = &wait_result {
-                let err_msg = format!("Failed to wait on condvar: {:?}", e);
+                let err_msg = format!("Failed to wait on condvar: {e:?}");
                 warn!("{}", err_msg);
                 return Err(err_msg);
             }
@@ -133,7 +133,7 @@ impl<T: Clone> AsyncResolve<T> {
         let value_lock_result = self.value.lock();
 
         if let Err(e) = &value_lock_result {
-            let err_msg = format!("Failed to lock value mutex after wait: {:?}", e);
+            let err_msg = format!("Failed to lock value mutex after wait: {e:?}");
             warn!("{}", err_msg);
             return Err(err_msg);
         }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -85,7 +85,7 @@ pub struct Layer {
 }
 
 /// A custom iterator that reads lines from a BufRead with lossy UTF-8 conversion
-/// This prevents the "stream did not contain valid UTF-8" error by converting 
+/// This prevents the "stream did not contain valid UTF-8" error by converting
 /// invalid UTF-8 bytes to replacement characters
 pub struct Utf8LossyLines<R> {
     buf: R,
@@ -102,13 +102,13 @@ impl<R: BufRead> Iterator for Utf8LossyLines<R> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut line_bytes = Vec::new();
-        
+
         match self.buf.read_until(b'\n', &mut line_bytes) {
             Ok(0) => None, // EOF
             Ok(_) => {
                 // Convert bytes to string with lossy conversion
                 let line_string = String::from_utf8_lossy(&line_bytes);
-                
+
                 // Remove trailing newline if present
                 let line = if line_string.ends_with('\n') {
                     let mut trimmed = line_string.into_owned();
@@ -120,7 +120,7 @@ impl<R: BufRead> Iterator for Utf8LossyLines<R> {
                 } else {
                     line_string.into_owned()
                 };
-                
+
                 Some(Ok(line))
             }
             Err(e) => Some(Err(e)),
@@ -201,7 +201,7 @@ impl Layer {
             }
         } else {
             // Print to stdout (default behavior)
-            println!("{}", line);
+            println!("{line}");
         }
     }
 
@@ -544,8 +544,7 @@ impl Layer {
         } else {
             // Not a message
             Err(format!(
-                "Failed to parse message, received raw content: {}",
-                content
+                "Failed to parse message, received raw content: {content}"
             ))
         }
     }
@@ -663,13 +662,13 @@ mod tests {
 
     #[test]
     fn test_utf8_error_handling() -> Result<(), String> {
+        use crate::layer::Utf8LossyLines;
         use std::io::BufRead;
         use std::process::{Command, Stdio};
-        use crate::layer::Utf8LossyLines;
-        
+
         // Instead of using the complex environment setup, let's create a simple test
         // that reproduces the UTF-8 issue by creating a child process that outputs invalid UTF-8
-        
+
         // Create a simple Python script that outputs invalid UTF-8 bytes
         let python_code = r#"
 import sys
@@ -694,33 +693,36 @@ sys.exit(0)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
-            .map_err(|e| format!("Failed to spawn Python process: {}", e))?;
+            .map_err(|e| format!("Failed to spawn Python process: {e}"))?;
 
         // Get the stdout handle
         let stdout = child.stdout.take().ok_or("Failed to get stdout")?;
-        
+
         // Test with standard Lines iterator first (should fail)
         println!("=== Testing with standard Lines iterator (should fail) ===");
         let reader = std::io::BufReader::new(stdout);
         let lines = reader.lines();
-        
+
         // Try to read lines - this should trigger the UTF-8 error
         let mut lines_read = 0;
         let mut utf8_errors = 0;
         let mut valid_lines = Vec::new();
-        
+
         for line_result in lines {
             match line_result {
                 Ok(line) => {
                     lines_read += 1;
                     valid_lines.push(line);
-                    println!("✅ Successfully read line: {:?}", valid_lines.last().unwrap());
+                    println!(
+                        "✅ Successfully read line: {:?}",
+                        valid_lines.last().unwrap()
+                    );
                 }
                 Err(e) => {
                     utf8_errors += 1;
                     let error_msg = e.to_string();
-                    println!("❌ Caught UTF-8 error: {}", error_msg);
-                    
+                    println!("❌ Caught UTF-8 error: {error_msg}");
+
                     // This is the error we're looking for
                     if error_msg.contains("stream did not contain valid UTF-8") {
                         println!("✅ Successfully reproduced the UTF-8 error with standard Lines!");
@@ -729,68 +731,75 @@ sys.exit(0)
                 }
             }
         }
-        
+
         // Wait for child process to complete
         let _ = child.wait();
-        
+
         if utf8_errors == 0 {
-            return Err("Expected to reproduce UTF-8 error with standard Lines, but didn't".to_string());
+            return Err(
+                "Expected to reproduce UTF-8 error with standard Lines, but didn't".to_string(),
+            );
         }
-        
+
         // Now test with our new child process using Utf8LossyLines
         println!("\n=== Testing with Utf8LossyLines iterator (should work) ===");
-        
+
         let mut child2 = Command::new("python")
             .arg("-c")
             .arg(python_code)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
-            .map_err(|e| format!("Failed to spawn second Python process: {}", e))?;
+            .map_err(|e| format!("Failed to spawn second Python process: {e}"))?;
 
         let stdout2 = child2.stdout.take().ok_or("Failed to get stdout2")?;
-        
+
         // Create our new UTF-8 lossy lines iterator
         let reader2 = std::io::BufReader::new(stdout2);
         let lossy_lines = Utf8LossyLines::new(reader2);
-        
+
         let mut lines_read2 = 0;
         let mut utf8_errors2 = 0;
         let mut valid_lines2 = Vec::new();
-        
+
         for line_result in lossy_lines {
             match line_result {
                 Ok(line) => {
                     lines_read2 += 1;
                     valid_lines2.push(line);
-                    println!("✅ Successfully read line with lossy UTF-8: {:?}", valid_lines2.last().unwrap());
+                    println!(
+                        "✅ Successfully read line with lossy UTF-8: {:?}",
+                        valid_lines2.last().unwrap()
+                    );
                 }
                 Err(e) => {
                     utf8_errors2 += 1;
-                    println!("❌ Unexpected error with Utf8LossyLines: {}", e);
+                    println!("❌ Unexpected error with Utf8LossyLines: {e}");
                 }
             }
         }
-        
+
         // Wait for child process to complete
         let _ = child2.wait();
-        
+
         println!("\n=== Results ===");
-        println!("Standard Lines: {} lines read, {} UTF-8 errors", lines_read, utf8_errors);
-        println!("Utf8LossyLines: {} lines read, {} UTF-8 errors", lines_read2, utf8_errors2);
-        
+        println!("Standard Lines: {lines_read} lines read, {utf8_errors} UTF-8 errors");
+        println!("Utf8LossyLines: {lines_read2} lines read, {utf8_errors2} UTF-8 errors");
+
         if utf8_errors2 > 0 {
-            return Err("Utf8LossyLines should handle invalid UTF-8 gracefully, but got errors".to_string());
+            return Err(
+                "Utf8LossyLines should handle invalid UTF-8 gracefully, but got errors".to_string(),
+            );
         }
-        
+
         if lines_read2 < 2 {
             return Err("Expected to read at least 2 lines with Utf8LossyLines".to_string());
         }
-        
+
         println!("✅ UTF-8 error handling test passed!");
         println!("   - Standard Lines iterator fails on invalid UTF-8 (as expected)");
         println!("   - Utf8LossyLines iterator handles invalid UTF-8 gracefully");
-        
+
         Ok(())
     }
 

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -61,8 +61,8 @@ pub enum ProcessResult {
 pub struct Layer {
     pub child: Child,                    // The forkable process with all imports loaded
     pub stdin: std::process::ChildStdin, // The stdin of the forkable process
-    pub reader: Option<std::io::Lines<BufReader<std::process::ChildStdout>>>, // The reader of the forkable process
-    pub stderr_reader: Option<std::io::Lines<BufReader<std::process::ChildStderr>>>, // The stderr reader of the forkable process
+    pub reader: Option<Utf8LossyLines<BufReader<std::process::ChildStdout>>>, // The reader of the forkable process
+    pub stderr_reader: Option<Utf8LossyLines<BufReader<std::process::ChildStderr>>>, // The stderr reader of the forkable process
 
     pub forked_processes: Arc<Mutex<HashMap<String, i32>>>, // Map of UUID to PID
     pub forked_names: Arc<Mutex<HashMap<String, String>>>,  // Map of UUID to name
@@ -84,19 +84,63 @@ pub struct Layer {
     pub buffer_output: bool,
 }
 
+/// A custom iterator that reads lines from a BufRead with lossy UTF-8 conversion
+/// This prevents the "stream did not contain valid UTF-8" error by converting 
+/// invalid UTF-8 bytes to replacement characters
+pub struct Utf8LossyLines<R> {
+    buf: R,
+}
+
+impl<R: BufRead> Utf8LossyLines<R> {
+    pub fn new(buf: R) -> Self {
+        Self { buf }
+    }
+}
+
+impl<R: BufRead> Iterator for Utf8LossyLines<R> {
+    type Item = std::io::Result<String>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut line_bytes = Vec::new();
+        
+        match self.buf.read_until(b'\n', &mut line_bytes) {
+            Ok(0) => None, // EOF
+            Ok(_) => {
+                // Convert bytes to string with lossy conversion
+                let line_string = String::from_utf8_lossy(&line_bytes);
+                
+                // Remove trailing newline if present
+                let line = if line_string.ends_with('\n') {
+                    let mut trimmed = line_string.into_owned();
+                    trimmed.pop();
+                    if trimmed.ends_with('\r') {
+                        trimmed.pop();
+                    }
+                    trimmed
+                } else {
+                    line_string.into_owned()
+                };
+                
+                Some(Ok(line))
+            }
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
 impl Layer {
     // New constructor for Layer with shared state
     pub fn new(
         child: Child,
         stdin: std::process::ChildStdin,
-        reader: std::io::Lines<BufReader<std::process::ChildStdout>>,
-        stderr_reader: std::io::Lines<BufReader<std::process::ChildStderr>>,
+        reader: BufReader<std::process::ChildStdout>,
+        stderr_reader: BufReader<std::process::ChildStderr>,
     ) -> Self {
         Self {
             child,
             stdin,
-            reader: Some(reader),
-            stderr_reader: Some(stderr_reader),
+            reader: Some(Utf8LossyLines::new(reader)),
+            stderr_reader: Some(Utf8LossyLines::new(stderr_reader)),
             forked_processes: Arc::new(Mutex::new(HashMap::new())),
             forked_names: Arc::new(Mutex::new(HashMap::new())),
             fork_resolvers: Arc::new(Mutex::new(HashMap::new())),
@@ -114,8 +158,8 @@ impl Layer {
     pub fn new_for_test(
         child: Child,
         stdin: std::process::ChildStdin,
-        reader: std::io::Lines<BufReader<std::process::ChildStdout>>,
-        stderr_reader: std::io::Lines<BufReader<std::process::ChildStderr>>,
+        reader: BufReader<std::process::ChildStdout>,
+        stderr_reader: BufReader<std::process::ChildStderr>,
     ) -> Self {
         let mut layer = Self::new(child, stdin, reader, stderr_reader);
         layer.buffer_output = true;
@@ -242,7 +286,7 @@ impl Layer {
     /// Common function to monitor a stream (stdout or stderr)
     #[allow(clippy::too_many_arguments)]
     fn monitor_stream<R: BufRead>(
-        reader: std::io::Lines<R>,
+        mut reader: Utf8LossyLines<R>,
         stream_name: &str,
         terminate_rx: mpsc::Receiver<()>,
         fork_resolvers: &Arc<Mutex<HashMap<String, AsyncResolve<ForkResult>>>>,
@@ -254,7 +298,6 @@ impl Layer {
         output_buffer: &Arc<Mutex<Option<OutputBuffer>>>,
     ) {
         info!("Monitor thread for {} started", stream_name);
-        let mut reader = reader;
 
         loop {
             // Check if we've been asked to terminate
@@ -617,6 +660,139 @@ impl Layer {
 mod tests {
     use crate::environment::Environment;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_utf8_error_handling() -> Result<(), String> {
+        use std::io::BufRead;
+        use std::process::{Command, Stdio};
+        use crate::layer::Utf8LossyLines;
+        
+        // Instead of using the complex environment setup, let's create a simple test
+        // that reproduces the UTF-8 issue by creating a child process that outputs invalid UTF-8
+        
+        // Create a simple Python script that outputs invalid UTF-8 bytes
+        let python_code = r#"
+import sys
+import os
+
+# Write invalid UTF-8 bytes directly to stdout
+sys.stdout.buffer.write(b'\xff\xfe\xfd\xfc This is invalid UTF-8\n')
+sys.stdout.buffer.flush()
+
+# Write some valid UTF-8 too
+sys.stdout.write('This is valid UTF-8\n')
+sys.stdout.flush()
+
+# Exit successfully
+sys.exit(0)
+"#;
+
+        // Create a child process that runs our Python code
+        let mut child = Command::new("python")
+            .arg("-c")
+            .arg(python_code)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("Failed to spawn Python process: {}", e))?;
+
+        // Get the stdout handle
+        let stdout = child.stdout.take().ok_or("Failed to get stdout")?;
+        
+        // Test with standard Lines iterator first (should fail)
+        println!("=== Testing with standard Lines iterator (should fail) ===");
+        let reader = std::io::BufReader::new(stdout);
+        let lines = reader.lines();
+        
+        // Try to read lines - this should trigger the UTF-8 error
+        let mut lines_read = 0;
+        let mut utf8_errors = 0;
+        let mut valid_lines = Vec::new();
+        
+        for line_result in lines {
+            match line_result {
+                Ok(line) => {
+                    lines_read += 1;
+                    valid_lines.push(line);
+                    println!("✅ Successfully read line: {:?}", valid_lines.last().unwrap());
+                }
+                Err(e) => {
+                    utf8_errors += 1;
+                    let error_msg = e.to_string();
+                    println!("❌ Caught UTF-8 error: {}", error_msg);
+                    
+                    // This is the error we're looking for
+                    if error_msg.contains("stream did not contain valid UTF-8") {
+                        println!("✅ Successfully reproduced the UTF-8 error with standard Lines!");
+                        break; // Don't continue since we demonstrated the error
+                    }
+                }
+            }
+        }
+        
+        // Wait for child process to complete
+        let _ = child.wait();
+        
+        if utf8_errors == 0 {
+            return Err("Expected to reproduce UTF-8 error with standard Lines, but didn't".to_string());
+        }
+        
+        // Now test with our new child process using Utf8LossyLines
+        println!("\n=== Testing with Utf8LossyLines iterator (should work) ===");
+        
+        let mut child2 = Command::new("python")
+            .arg("-c")
+            .arg(python_code)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("Failed to spawn second Python process: {}", e))?;
+
+        let stdout2 = child2.stdout.take().ok_or("Failed to get stdout2")?;
+        
+        // Create our new UTF-8 lossy lines iterator
+        let reader2 = std::io::BufReader::new(stdout2);
+        let lossy_lines = Utf8LossyLines::new(reader2);
+        
+        let mut lines_read2 = 0;
+        let mut utf8_errors2 = 0;
+        let mut valid_lines2 = Vec::new();
+        
+        for line_result in lossy_lines {
+            match line_result {
+                Ok(line) => {
+                    lines_read2 += 1;
+                    valid_lines2.push(line);
+                    println!("✅ Successfully read line with lossy UTF-8: {:?}", valid_lines2.last().unwrap());
+                }
+                Err(e) => {
+                    utf8_errors2 += 1;
+                    println!("❌ Unexpected error with Utf8LossyLines: {}", e);
+                }
+            }
+        }
+        
+        // Wait for child process to complete
+        let _ = child2.wait();
+        
+        println!("\n=== Results ===");
+        println!("Standard Lines: {} lines read, {} UTF-8 errors", lines_read, utf8_errors);
+        println!("Utf8LossyLines: {} lines read, {} UTF-8 errors", lines_read2, utf8_errors2);
+        
+        if utf8_errors2 > 0 {
+            return Err("Utf8LossyLines should handle invalid UTF-8 gracefully, but got errors".to_string());
+        }
+        
+        if lines_read2 < 2 {
+            return Err("Expected to read at least 2 lines with Utf8LossyLines".to_string());
+        }
+        
+        println!("✅ UTF-8 error handling test passed!");
+        println!("   - Standard Lines iterator fails on invalid UTF-8 (as expected)");
+        println!("   - Utf8LossyLines iterator handles invalid UTF-8 gracefully");
+        
+        Ok(())
+    }
 
     #[test]
     fn test_stderr_handling() -> Result<(), String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,14 +131,14 @@ fn update_environment(_py: Python, env_id: &str) -> PyResult<bool> {
     info!("Updating environment for runner: {}", env_id);
     let mut environments = ENVIRONMENTS.lock().unwrap();
     let environment = environments.get_mut(env_id).ok_or_else(|| {
-        let err_msg = format!("No import runner found with ID: {}", env_id);
+        let err_msg = format!("No import runner found with ID: {env_id}");
         error!("{}", err_msg);
         PyRuntimeError::new_err(err_msg)
     })?;
 
     // Update the environment using the runner's method
     let updated = environment.update_environment().map_err(|e| {
-        let err_msg = format!("Failed to update environment: {}", e);
+        let err_msg = format!("Failed to update environment: {e}");
         error!("{}", err_msg);
         PyRuntimeError::new_err(err_msg)
     })?;
@@ -162,7 +162,7 @@ fn stop_import_runner(_py: Python, env_id: &str) -> PyResult<()> {
     eprintln!(
         "\n{} {}\n",
         "⏹".yellow().bold(),
-        format!("Stopping environment {}", env_id).white().bold()
+        format!("Stopping environment {env_id}").white().bold()
     );
 
     let start_time = Instant::now();
@@ -171,7 +171,7 @@ fn stop_import_runner(_py: Python, env_id: &str) -> PyResult<()> {
     if let Some(environment) = environments.remove(env_id) {
         // Clean up resources
         environment.stop_main().map_err(|e| {
-            let err_msg = format!("Failed to stop environment: {}", e);
+            let err_msg = format!("Failed to stop environment: {e}");
             error!("{}", err_msg);
             PyRuntimeError::new_err(err_msg)
         })?;
@@ -188,7 +188,7 @@ fn stop_import_runner(_py: Python, env_id: &str) -> PyResult<()> {
 
         Ok(())
     } else {
-        let err_msg = format!("No environment found with ID: {}", env_id);
+        let err_msg = format!("No environment found with ID: {env_id}");
         error!("{}", err_msg);
 
         // Log the error with owo_colors
@@ -235,7 +235,7 @@ fn exec_isolated<'py>(
         match environment.exec_isolated(&pickled_data, name) {
             Ok(result) => {
                 debug!("Function executed successfully in isolated process");
-                Ok(py.eval(&format!("'{}'", result), None, None)?)
+                Ok(py.eval(&format!("'{result}'"), None, None)?)
             }
             Err(err) => {
                 error!("Error executing function in isolated process: {}", err);
@@ -243,7 +243,7 @@ fn exec_isolated<'py>(
             }
         }
     } else {
-        let err_msg = format!("No import runner found with ID: {}", env_id);
+        let err_msg = format!("No import runner found with ID: {env_id}");
         error!("{}", err_msg);
         Err(PyRuntimeError::new_err(err_msg))
     }
@@ -259,12 +259,12 @@ fn stop_isolated(_py: Python, env_id: &str, process_uuid: &str) -> PyResult<bool
     let environments = ENVIRONMENTS.lock().unwrap();
     if let Some(environment) = environments.get(env_id) {
         environment.stop_isolated(process_uuid).map_err(|e| {
-            let err_msg = format!("Failed to stop isolated process: {}", e);
+            let err_msg = format!("Failed to stop isolated process: {e}");
             error!("{}", err_msg);
             PyRuntimeError::new_err(err_msg)
         })
     } else {
-        let err_msg = format!("No import environment found with ID: {}", env_id);
+        let err_msg = format!("No import environment found with ID: {env_id}");
         error!("{}", err_msg);
         Err(PyRuntimeError::new_err(err_msg))
     }
@@ -280,13 +280,13 @@ fn communicate_isolated(_py: Python, env_id: &str, process_uuid: &str) -> PyResu
     let environments = ENVIRONMENTS.lock().unwrap();
     if let Some(environment) = environments.get(env_id) {
         environment.communicate_isolated(process_uuid).map_err(|e| {
-            let err_msg = format!("Child process error: {}", e);
+            let err_msg = format!("Child process error: {e}");
             error!("{}", err_msg);
             // Use the standard PyRuntimeError instead of custom exception
             PyRuntimeError::new_err(err_msg)
         })
     } else {
-        let err_msg = format!("No import environment found with ID: {}", env_id);
+        let err_msg = format!("No import environment found with ID: {env_id}");
         error!("{}", err_msg);
         Err(PyRuntimeError::new_err(err_msg))
     }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -259,7 +259,7 @@ pub mod io {
         message: &M,
     ) -> std::io::Result<()> {
         let json = serde_json::to_string(message)?;
-        writeln!(writer, "{}", json)?;
+        writeln!(writer, "{json}")?;
         Ok(())
     }
 
@@ -288,7 +288,7 @@ mod tests {
         // Wrap the inner struct in the Message enum so that the "name" tag is added.
         let msg = Message::ImportComplete(ImportComplete::new());
         let serialized = serde_json::to_string(&msg).unwrap();
-        println!("Serialized ImportComplete: {}", serialized);
+        println!("Serialized ImportComplete: {serialized}");
         // Expected output includes "IMPORT_COMPLETE" as the tag.
         assert!(serialized.contains("IMPORT_COMPLETE"));
     }
@@ -319,7 +319,7 @@ mod tests {
         if let Ok(message) = parsed {
             match message {
                 Message::ImportComplete(_) => (), // Success
-                _ => panic!("Parsed to wrong variant: {:?}", message),
+                _ => panic!("Parsed to wrong variant: {message:?}"),
             }
         }
     }

--- a/src/multiplex_logs.rs
+++ b/src/multiplex_logs.rs
@@ -20,9 +20,9 @@ pub enum MultiplexedLogLineError {
 impl std::fmt::Display for MultiplexedLogLineError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::InvalidFormat(msg) => write!(f, "Invalid log format: {}", msg),
-            Self::PidParseError(err) => write!(f, "Failed to parse PID: {}", err),
-            Self::MissingComponent(msg) => write!(f, "Missing component: {}", msg),
+            Self::InvalidFormat(msg) => write!(f, "Invalid log format: {msg}"),
+            Self::PidParseError(err) => write!(f, "Failed to parse PID: {err}"),
+            Self::MissingComponent(msg) => write!(f, "Missing component: {msg}"),
         }
     }
 }
@@ -68,8 +68,7 @@ pub fn parse_multiplexed_line(line: &str) -> Result<MultiplexedLogLine, Multiple
 
     if parts.len() != 2 {
         return Err(MultiplexedLogLineError::InvalidFormat(format!(
-            "Expected format [PID:pid:stream_name], got [PID:{}]",
-            prefix
+            "Expected format [PID:pid:stream_name], got [PID:{prefix}]"
         )));
     }
 

--- a/src/test_utils/harness.rs
+++ b/src/test_utils/harness.rs
@@ -101,25 +101,25 @@ pub fn prepare_script_for_isolation(
 ) -> Result<(String, PythonPathGuard), String> {
     // Create a temporary directory for the script
     let temp_dir =
-        TempDir::new().map_err(|e| format!("Failed to create temporary directory: {}", e))?;
+        TempDir::new().map_err(|e| format!("Failed to create temporary directory: {e}"))?;
 
     // Create a valid Python module name (no dashes, start with letter)
     let module_name = format!("pymodule{}", Uuid::new_v4().to_string().replace("-", ""));
 
     // Create the module directory inside the temp directory
     let module_dir = temp_dir.path().join(&module_name);
-    fs::create_dir(&module_dir).map_err(|e| format!("Failed to create module directory: {}", e))?;
+    fs::create_dir(&module_dir).map_err(|e| format!("Failed to create module directory: {e}"))?;
 
     // Create __init__.py inside the module directory to make it a proper package
     let init_path = module_dir.join("__init__.py");
     fs::write(&init_path, "# Package initialization")
-        .map_err(|e| format!("Failed to write __init__.py file: {}", e))?;
+        .map_err(|e| format!("Failed to write __init__.py file: {e}"))?;
 
     // Create the script file inside the module directory (using a standard name)
     let script_file_name = "script.py";
     let script_path = module_dir.join(script_file_name);
     fs::write(&script_path, python_script)
-        .map_err(|e| format!("Failed to write script to file: {}", e))?;
+        .map_err(|e| format!("Failed to write script to file: {e}"))?;
 
     // At this point our directory looks like:
     // pymodule
@@ -156,7 +156,7 @@ print(pickled_data)
     // Write the pickle script directly to the temp directory (not in the module)
     let pickle_script_path = temp_dir.path().join("pickle_helper.py");
     fs::write(&pickle_script_path, pickle_script)
-        .map_err(|e| format!("Failed to write pickle script to temporary file: {}", e))?;
+        .map_err(|e| format!("Failed to write pickle script to temporary file: {e}"))?;
 
     // Serialize the payload to a JSON string
     let json_payload = isolation_payload.to_string();
@@ -175,12 +175,12 @@ print(pickled_data)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| format!("Failed to spawn Python process: {}", e))?;
+        .map_err(|e| format!("Failed to spawn Python process: {e}"))?;
 
     // Get the output
     let output = child
         .wait_with_output()
-        .map_err(|e| format!("Failed to get Python process output: {}", e))?;
+        .map_err(|e| format!("Failed to get Python process output: {e}"))?;
 
     // Log stderr for debugging
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -190,7 +190,7 @@ print(pickled_data)
 
     // Check if the process executed successfully
     if !output.status.success() {
-        return Err(format!("Python pickling failed: {}", stderr));
+        return Err(format!("Python pickling failed: {stderr}"));
     }
 
     // Parse the output (base64 encoded pickled data)
@@ -231,7 +231,7 @@ def main():
         // Verify the pickled data is valid base64
         let _decoded = base64::engine::general_purpose::STANDARD
             .decode(pickled_data)
-            .map_err(|e| format!("Invalid base64: {}", e))?;
+            .map_err(|e| format!("Invalid base64: {e}"))?;
 
         Ok(())
     }


### PR DESCRIPTION
While testing some more complex projects we've seen this error locally:

```
[2025-06-30T22:06:28Z ERROR firehot::layer] Error reading from child process stdout: stream did not contain valid UTF-8
```

`monitor_stream` was using `std::io::Lines` to read from child process stdout/stderr streams. The `Lines` iterator expects all input to be valid UTF-8, but child processes can output invalid UTF-8 bytes, causing the iterator to fail with a UTF-8 decoding error.