### PR TITLE
Trace failing imports

### DIFF
--- a/firehot/__tests__/embedded/test_import_error_display.py
+++ b/firehot/__tests__/embedded/test_import_error_display.py
@@ -1,0 +1,72 @@
+"""
+Test the pretty print import error functionality
+"""
+
+import os
+import tempfile
+
+from firehot.embedded.parent_entrypoint import pretty_print_import_error
+
+
+def test_pretty_print_import_error():
+    # Create a temporary file with some import statements
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write("""import os
+import sys
+import nonexistent_module  # This will fail
+
+def some_function():
+    import another_bad_module
+    pass
+""")
+        temp_file = f.name
+
+    try:
+        # Create module locations data
+        module_locations = {
+            "nonexistent_module": [
+                {
+                    "file_path": temp_file,
+                    "line": 3,
+                    "column": 1,
+                    "end_line": None,
+                    "end_column": None,
+                }
+            ],
+            "another_bad_module": [
+                {
+                    "file_path": temp_file,
+                    "line": 6,
+                    "column": 5,
+                    "end_line": None,
+                    "end_column": None,
+                }
+            ],
+        }
+
+        # Test with a module that has location info
+        error = ImportError("No module named 'nonexistent_module'")
+        result = pretty_print_import_error(error, "nonexistent_module", module_locations)
+
+        print("Pretty printed error:")
+        print(result)
+
+        # Verify the output contains expected elements
+        assert "ImportError: No module named 'nonexistent_module'" in result
+        assert f'File "{temp_file}", line 3' in result
+        assert "import nonexistent_module" in result
+        assert "> " in result  # The line indicator
+
+        # Test with a module that doesn't have location info
+        error2 = ImportError("No module named 'unknown_module'")
+        result2 = pretty_print_import_error(error2, "unknown_module", module_locations)
+
+        print("\nError for module without location info:")
+        print(result2)
+
+        assert "ImportError: No module named 'unknown_module'" in result2
+        assert "File" not in result2  # Should not contain file info
+
+    finally:
+        # Clean up
+        os.unlink(temp_file)

--- a/firehot/__tests__/embedded/test_parent_entrypoint.py
+++ b/firehot/__tests__/embedded/test_parent_entrypoint.py
@@ -250,21 +250,21 @@ def test_execute_dynamic_imports(caplog: LogCaptureFixture) -> None:
     logger = logging.getLogger()
 
     # Test empty input
-    execute_dynamic_imports("", logger)
+    execute_dynamic_imports("", logger, {})
     assert len(caplog.records) == 0
 
     # Test invalid JSON
     with pytest.raises(SystemExit):
-        execute_dynamic_imports("invalid json", logger)
+        execute_dynamic_imports("invalid json", logger, {})
 
     # Test invalid type (not a list)
     with pytest.raises(SystemExit):
-        execute_dynamic_imports('{"not": "a list"}', logger)
+        execute_dynamic_imports('{"not": "a list"}', logger, {})
 
     # Test valid list of imports
     with patch("firehot.embedded.parent_entrypoint.track_and_execute_import") as mock_import:
         modules = ["json", "sys", "os"]
-        execute_dynamic_imports(json.dumps(modules), logger)
+        execute_dynamic_imports(json.dumps(modules), logger, {})
 
         # Verify each module was imported
         assert mock_import.call_count == len(modules)

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -942,7 +942,7 @@ import time
 
 def main():
     # Sleep for a while to simulate a long-running process
-    for i in range(10):
+    for i in range(5):
         time.sleep(0.1)
     return "Long running process completed"
         "#;
@@ -978,8 +978,8 @@ def main():
             .exec_isolated(&pickled_long_running, "long-runner-2")
             .expect("Failed to execute second function");
 
-        // Give it a moment to complete
-        std::thread::sleep(std::time::Duration::from_millis(1500));
+        // Give it enough time to complete (0.5s script execution + overhead)
+        std::thread::sleep(std::time::Duration::from_millis(2000));
 
         // Verify we can communicate with the second process
         let result = runner

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Result};
 use log::{debug, error, info, warn};
 use owo_colors::OwoColorize;
 use serde_json::{self};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufReader, Write};
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
@@ -102,11 +102,14 @@ impl Environment {
         let start_time = Instant::now();
 
         // Spawn Python subprocess to load modules
+        // Get module locations for error reporting
+        let module_locations = self.ast_manager.get_module_locations();
+
         info!(
             "Spawning Python subprocess to load {} modules",
             third_party_modules.len()
         );
-        let mut child = spawn_python_loader(&third_party_modules)
+        let mut child = spawn_python_loader(&third_party_modules, &module_locations)
             .map_err(|e| format!("Failed to spawn Python loader: {e}"))?;
 
         let stdin = child
@@ -566,17 +569,26 @@ pickled_str = "{pickled_data}"
 /// Spawn a Python process that imports the given modules and then waits for commands on stdin.
 /// The Python process prints "IMPORTS_LOADED" to stdout once all imports are complete.
 /// After that, it will listen for commands on stdin, which can include fork requests and code to execute.
-fn spawn_python_loader(modules: &HashSet<String>) -> Result<Child> {
+fn spawn_python_loader(
+    modules: &HashSet<String>,
+    module_locations: &HashMap<String, Vec<crate::ast::SourceLocation>>,
+) -> Result<Child> {
     // Convert modules to a JSON list of module names
     let import_json = serde_json::to_string(&Vec::from_iter(modules.iter().cloned()))
         .map_err(|e| anyhow!("Failed to serialize module names: {}", e))?;
 
     debug!("Module import JSON: {}", import_json);
 
+    // Convert module locations to JSON
+    let locations_json = serde_json::to_string(&module_locations)
+        .map_err(|e| anyhow!("Failed to serialize module locations: {}", e))?;
+    debug!("Module locations JSON: {}", locations_json);
+
     // Spawn Python process with all modules pre-imported
     let child = Command::new("python")
         .args(["-c", PYTHON_LOADER_SCRIPT])
         .arg(import_json)
+        .arg(locations_json)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -534,6 +534,20 @@ impl Layer {
                     error!("Monitor thread received unknown error: {}", error.error);
                     Ok(())
                 }
+                Message::ImportError(error) => {
+                    // Import errors occur during initialization and should be fatal
+                    error!("Monitor thread received import error:\n{}", error.error);
+                    if let Some(traceback) = &error.traceback {
+                        error!("Import error traceback:\n{}", traceback);
+                    }
+                    // Exit the process with error code to indicate import failure
+                    std::process::exit(1);
+                }
+                Message::ImportComplete(_) => {
+                    // Import completion is informational
+                    info!("Monitor thread received import complete message");
+                    Ok(())
+                }
                 _ => {
                     // We should have a handler implemented for all messages types, capture the
                     // unknown ones


### PR DESCRIPTION
Since we are importing packages in an isolated context devoid from user code, it's been difficult to determine which files are causing the missing import exception. This PR captures import locations alongside our AST analysis of the original user code so we can provide contextualized error messages if we fail imports.